### PR TITLE
Restore location api call

### DIFF
--- a/src/lib/classes.js
+++ b/src/lib/classes.js
@@ -82,7 +82,7 @@ export class RuralTest {
     // https://github.com/sveltejs/kit/pull/3993
 
     // key for account using ruralnet@codeforuv.org
-    // this.ABSTRACT_API = "de24077830ea4d369cb85de93599c45c";
+    //this.ABSTRACT_API = "de24077830ea4d369cb85de93599c45c";
 
     // key for account using lynn.jms@gmail.com
     this.ABSTRACT_API = "24b20bbcf9d1412e9deae17b60cd692a";
@@ -133,7 +133,7 @@ export class RuralTest {
     );
     try {
       const resp = await fetch(
-        `https://ipgeolocation.abstractapi.com/v1/?api_key=${this.ABSTRACT_API} & ip_address = "2600:4040:5714:3a00:d98d:8499:e47e:a240"`
+        `https://ipgeolocation.abstractapi.com/v1/?api_key=${this.ABSTRACT_API}`
       );
       this.geolocationData = await resp.json();
       return true;
@@ -145,10 +145,9 @@ export class RuralTest {
 
   async checkDBForPrevTest() {
     this.addLogMsg("Checking db for existing test for this IP + userid");
+    let ipaddr = this.geolocationData?.ip_address;
     try {
-      const previousTestReq = await fetch(
-        `/api/v1/findUser?ip=${this.geolocationData?.ip_address}`
-      );
+      const previousTestReq = await fetch(`/api/v1/findUser?ip=${ipaddr}`);
       let prevTestMeta = await previousTestReq.json();
       if (!prevTestMeta.err) {
         this.addLogMsg(

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -41,7 +41,7 @@
     <a href="/" class="p-3">Home</a>
     <a href="about" class="p-3">About</a>
     <a href="results" class="p-3">Results</a>
-    <a href="/" class="py-3">API Fix 2</a>
+    <a href="/" class="py-3">API Fix 3</a>
   </div>
 
   {#if $page.url.pathname !== "/"}


### PR DESCRIPTION
I did some digging and I’m pretty sure the geolocation error is in the ‘FindUser’ function where it’s looking for previous tests in the DB and not the Abstract API, even though it looks like the API in the console.
If I comment out FindUser temporarily and just assume it’s the users first time on the site, everything works great.

So I'd like to deploy this PR to see if we get lucky and it's working now, or if not to see the errors without the hard-coded ip address.